### PR TITLE
fixed trivy scan, again :(

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
         severity: 'CRITICAL,HIGH,MEDIUM'
         
     - name: Run Trivy vulnerability scanner - Frontend
-      uses: aquasecurity/trivy-action@v0.32.0
+      uses: aquasecurity/trivy-action@0.32.0
       with:
         image-ref: ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/frontend:run-${{ github.run_id }}
         format: 'sarif'


### PR DESCRIPTION
This pull request includes a minor fix to the CI workflow configuration. The change updates the version reference for the Trivy vulnerability scanner action to use the correct format.

* Updated the `uses` field for the Trivy vulnerability scanner in `.github/workflows/ci.yml` from `v0.32.0` to `0.32.0` to ensure the correct version is used.