### PR TITLE
updated CI for packages permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-push-images, security-scan]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    permissions:
+      packages: write
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
This pull request introduces a permissions update to the CI workflow configuration to support package-related actions.

CI workflow permissions:

* Added a `permissions` block with `packages: write` to the `jobs:` section in `.github/workflows/ci.yml`, enabling the workflow to write to GitHub Packages.