### PR TITLE
updating the workflow conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,8 @@ jobs:
     name: Build and Push Container Images
     runs-on: ubuntu-latest
     needs: [test-backend, test-frontend]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
-    
+    if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')) || github.event_name == 'workflow_dispatch'
+
     permissions:
       contents: read
       packages: write
@@ -300,7 +300,7 @@ jobs:
     name: Security Scanning
     runs-on: ubuntu-latest
     needs: build-and-push-images
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')) || github.event_name == 'workflow_dispatch'
     
     permissions:
       contents: read


### PR DESCRIPTION
This pull request updates the CI workflow configuration to improve flexibility in how jobs are triggered. The main change is to allow certain jobs to run not only on pushes to the `main` or `develop` branches, but also when the workflow is manually triggered via `workflow_dispatch`.

Workflow trigger improvements:

* The `Build and Push Container Images` job will now run when the workflow is manually triggered (`workflow_dispatch`), in addition to pushes to the `main` or `develop` branches. (`.github/workflows/ci.yml`, [.github/workflows/ci.ymlL215-R215](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL215-R215))
* The `Security Scanning` job will also run on manual workflow dispatches, as well as on pushes to the `main` or `develop` branches. (`.github/workflows/ci.yml`, [.github/workflows/ci.ymlL303-R303](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL303-R303))