### PR TITLE
upated main.bicep for aoai

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -227,13 +227,14 @@ module openAI 'br/public:avm/res/cognitive-services/account:0.10.1' = {
         model: {
           format: 'OpenAI'
           name: 'gpt-4'
-          version: '0613'
+          version: 'turbo-2024-04-09'
         }
-        raiPolicyName: 'Microsoft.Default'
+        raiPolicyName: 'Microsoft.DefaultV2'
         sku: {
-          name: 'Standard'
-          capacity: environment == 'prod' ? 20 : 10
+          name: 'GlobalStandard'
+          capacity: 30
         }
+        versionUpgradeOption: 'OnceNewDefaultVersionAvailable'
       }
     ]
     diagnosticSettings: [


### PR DESCRIPTION
This pull request updates the OpenAI cognitive services account configuration in `infra/main.bicep` to use newer model and policy versions, increases resource capacity, and enables automatic version upgrades. These changes help ensure the service uses the latest capabilities and is better prepared for increased usage.

Model and policy updates:

* Changed the model version for `gpt-4` from `'0613'` to `'turbo-2024-04-09'`, providing access to improved model features.
* Updated the responsible AI policy from `'Microsoft.Default'` to `'Microsoft.DefaultV2'` for enhanced compliance and safety.

Resource and upgrade configuration:

* Changed the SKU name from `'Standard'` to `'GlobalStandard'` and increased the capacity to `30` for improved performance and scalability.
* Enabled automatic version upgrades by setting `versionUpgradeOption` to `'OnceNewDefaultVersionAvailable'`, ensuring the service stays up to date.