### PR TITLE
Changed location to eastus2 to match rg

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  AZURE_LOCATION: eastus
+  AZURE_LOCATION: eastus2
 
 jobs:
   deploy:

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -225,7 +225,7 @@ az cognitiveservices account create \
   --resource-group your-rg \
   --kind OpenAI \
   --sku S0 \
-  --location eastus
+  --location eastus2
 
 # Deploy GPT-4 model
 az cognitiveservices account deployment create \

--- a/infra/README.md
+++ b/infra/README.md
@@ -84,7 +84,7 @@ az bicep build-params --file parameters/main.prod.bicepparam
 # Create resource group
 az group create \
   --name rg-azure-devops-agent-dev \
-  --location eastus \
+  --location eastus2 \
   --tags environment=dev project=azure-devops-agent
 
 # Deploy to development
@@ -100,7 +100,7 @@ az deployment group create \
 # Create resource group
 az group create \
   --name rg-azure-devops-agent-prod \
-  --location eastus \
+  --location eastus2 \
   --tags environment=prod project=azure-devops-agent
 
 # Deploy to production
@@ -175,10 +175,10 @@ az keyvault secret set \
 
 ```bash
 # Check backend health
-curl https://azdo-ai-agent-dev-backend.proudsand-12345.eastus.azurecontainerapps.io/health
+curl https://azdo-ai-agent-dev-backend.proudsand-12345.eastus2.azurecontainerapps.io/health
 
 # Check frontend accessibility
-curl https://azdo-ai-agent-dev-frontend.proudsand-12345.eastus.azurecontainerapps.io
+curl https://azdo-ai-agent-dev-frontend.proudsand-12345.eastus2.azurecontainerapps.io
 ```
 
 ## Resource Naming Convention

--- a/infra/parameters/main.dev.bicepparam
+++ b/infra/parameters/main.dev.bicepparam
@@ -3,7 +3,7 @@ using '../main.bicep'
 
 // Environment configuration
 param environment = 'dev'
-param location = 'eastus'
+param location = 'eastus2'
 param appNamePrefix = 'azdo-ai-agent'
 
 // Azure DevOps configuration

--- a/infra/parameters/main.dev.json
+++ b/infra/parameters/main.dev.json
@@ -6,7 +6,7 @@
       "value": "dev"
     },
     "location": {
-      "value": "eastus"
+      "value": "eastus2"
     },
     "appNamePrefix": {
       "value": "azdo-ai-agent"

--- a/infra/parameters/main.prod.bicepparam
+++ b/infra/parameters/main.prod.bicepparam
@@ -3,7 +3,7 @@ using '../main.bicep'
 
 // Environment configuration
 param environment = 'prod'
-param location = 'eastus'
+param location = 'eastus2'
 param appNamePrefix = 'azdo-ai-agent'
 
 // Azure DevOps configuration

--- a/infra/parameters/main.prod.json
+++ b/infra/parameters/main.prod.json
@@ -6,7 +6,7 @@
       "value": "prod"
     },
     "location": {
-      "value": "eastus"
+      "value": "eastus2"
     },
     "appNamePrefix": {
       "value": "azdo-ai-agent"


### PR DESCRIPTION
This pull request updates the default Azure region for deployments and resource provisioning from `eastus` to `eastus2` across the codebase and documentation. This ensures consistency in environment configuration and aligns all scripts, parameter files, and documentation with the new region.

**Infrastructure and Deployment Configuration:**

* Changed the `location` parameter from `eastus` to `eastus2` in both development and production Bicep parameter files (`infra/parameters/main.dev.bicepparam`, `infra/parameters/main.prod.bicepparam`) and their corresponding JSON files (`infra/parameters/main.dev.json`, `infra/parameters/main.prod.json`). [[1]](diffhunk://#diff-71ce2b246994009721455d4a0d9d64e71a803883ba81a51148b722ce5d5496f6L6-R6) [[2]](diffhunk://#diff-8895e7f90d8d8b2f805c30bf4a9ffa67b4d6ed3e784553813df382cc925f1e3cL9-R9) [[3]](diffhunk://#diff-e9f9b9857c206160a8e659e93c2e6184d35f7f77b93e3afbe3c2ee2a3dcbdcfcL6-R6) [[4]](diffhunk://#diff-68479a55331689965a9fd7976b20d03169fc7d6042e3ddec4122d69c45edbe42L9-R9)
* Updated resource group creation and deployment commands in `infra/README.md` to use `eastus2` instead of `eastus` for both dev and prod environments. [[1]](diffhunk://#diff-a7185b3c971728dd36f544a064be689d9d77aef5a91e271608c5d0324c3710c4L87-R87) [[2]](diffhunk://#diff-a7185b3c971728dd36f544a064be689d9d77aef5a91e271608c5d0324c3710c4L103-R103)

**Documentation and Workflow Updates:**

* Modified example Azure CLI commands in `docs/development/setup.md` to use `eastus2` for Cognitive Services account creation.
* Updated health check and frontend accessibility URLs in `infra/README.md` to reflect the new region in the domain names.
* Changed the `AZURE_LOCATION` environment variable in the GitHub Actions workflow (`.github/workflows/deploy.yml`) to `eastus2`.