### PR TITLE
updated port mapping for front end to match next app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -213,7 +213,7 @@ jobs:
           --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
           --app-name "${{ env.FRONTEND_APP_NAME }}" \
           --image "${{ steps.deploy-infra.outputs.containerRegistryLoginServer }}/frontend:${{ env.RELEASE_TAG }}" \
-          --target-port 7860 \
+          --target-port 3000 \
           --registry-server "${{ steps.deploy-infra.outputs.containerRegistryLoginServer }}" \
           --registry-identity system \
           --managed-identity "${{ steps.deploy-infra.outputs.frontendManagedIdentityResourceId }}" \


### PR DESCRIPTION
This pull request makes a small but important change to the deployment configuration for the frontend application. The target port for the container in the Azure deployment workflow has been updated.

* Changed the `--target-port` for the frontend container in `.github/workflows/deploy.yml` from `7860` to `3000`, aligning the deployment configuration with the application's expected port.