### PR TITLE
updated reference to log analytics key

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -374,7 +374,7 @@ module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.11.
       destination: 'azure-monitor'
       logAnalyticsConfiguration: {
         customerId: logAnalytics.outputs.logAnalyticsWorkspaceId
-        sharedKey: listKeys(resourceId('Microsoft.OperationalInsights/workspaces', resourceNames.logAnalytics), '2025-02-01')[0].primarySharedKey
+        sharedKey: listKeys(resourceId('Microsoft.OperationalInsights/workspaces', resourceNames.logAnalytics), '2025-02-01')d.primarySharedKey
       }
     }
     zoneRedundant: false


### PR DESCRIPTION
This pull request makes a minor change to the way the shared key is accessed for the Log Analytics workspace in the `containerAppsEnvironment` module. The change corrects the method of accessing the `primarySharedKey` property from the result of the `listKeys` function.

* Fixed the reference to `primarySharedKey` by accessing it directly from the object returned by `listKeys`, instead of from the first element of an array.