### PR TITLE
fixed a silly typo

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -374,7 +374,7 @@ module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.11.
       destination: 'azure-monitor'
       logAnalyticsConfiguration: {
         customerId: logAnalytics.outputs.logAnalyticsWorkspaceId
-        sharedKey: listKeys(resourceId('Microsoft.OperationalInsights/workspaces', resourceNames.logAnalytics), '2025-02-01')d.primarySharedKey
+        sharedKey: listKeys(resourceId('Microsoft.OperationalInsights/workspaces', resourceNames.logAnalytics), '2025-02-01').primarySharedKey
       }
     }
     zoneRedundant: false


### PR DESCRIPTION
This pull request corrects a minor syntax error in the Bicep configuration for the container apps environment. The change ensures the correct retrieval of the Log Analytics shared key.

* Fixed a typo in the `sharedKey` assignment by replacing `d.primarySharedKey` with `.primarySharedKey`, ensuring the correct property is accessed from the result of `listKeys`. (`infra/main.bicep`)