### PR TITLE
this freakin thing

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -372,10 +372,6 @@ module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.11.
     tags: tags
     appLogsConfiguration: {
       destination: 'azure-monitor'
-      logAnalyticsConfiguration: {
-        customerId: logAnalytics.outputs.logAnalyticsWorkspaceId
-        sharedKey: listKeys(resourceId('Microsoft.OperationalInsights/workspaces', resourceNames.logAnalytics), '2025-02-01').primarySharedKey
-      }
     }
     zoneRedundant: false
     publicNetworkAccess: 'Enabled'


### PR DESCRIPTION
This pull request makes a targeted change to the logging configuration for the `containerAppsEnvironment` module in `infra/main.bicep`. The update removes the explicit configuration for Log Analytics, simplifying the app logs setup.

Logging configuration update:

* Removed the `logAnalyticsConfiguration` block from `appLogsConfiguration`, which previously set the workspace ID and shared key for Log Analytics. Now, only the destination (`azure-monitor`) is specified.