### PR TITLE
ok, I guess this thing works now?

### DIFF
--- a/src/backend/dotnet/AzureDevOpsAI.Backend/Services/AzureDevOpsApiService.cs
+++ b/src/backend/dotnet/AzureDevOpsAI.Backend/Services/AzureDevOpsApiService.cs
@@ -44,7 +44,7 @@ public class AzureDevOpsApiService : IAzureDevOpsApiService
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    public AzureDevOpsApiService(HttpClient httpClient, ILogger<AzureDevOpsApiService> logger, IOptions<AzureOpenAISettings> azureOpenAISettings)
+    public AzureDevOpsApiService(HttpClient httpClient, ILogger<AzureDevOpsApiService> logger, IOptions<AzureAuthSettings> azureAuthSettings)
     {
         _httpClient = httpClient;
         _logger = logger;
@@ -52,18 +52,10 @@ public class AzureDevOpsApiService : IAzureDevOpsApiService
         // Configure DefaultAzureCredential with optional User Assigned Managed Identity client ID
         var credentialOptions = new DefaultAzureCredentialOptions();
         
-        if (azureOpenAISettings.Value.UseUserAssignedIdentity)
-        {
-            credentialOptions.ManagedIdentityClientId = azureOpenAISettings.Value.ClientId;
-            credentialOptions.TenantId = azureOpenAISettings.Value.TenantId;
-            _credential = new DefaultAzureCredential(credentialOptions);
-            _logger.LogInformation("AzureDevOpsApiService initialized with DefaultAzureCredential using User Assigned Managed Identity client ID: {ClientId}", azureOpenAISettings.Value.ClientId);
-        }
-        else
-        {
-            _credential = new DefaultAzureCredential(credentialOptions);
-            _logger.LogInformation("AzureDevOpsApiService initialized with DefaultAzureCredential without User Assigned Managed Identity");
-        }
+        credentialOptions.ManagedIdentityClientId = azureAuthSettings.Value.ClientId;
+        credentialOptions.TenantId = azureAuthSettings.Value.TenantId;
+        _credential = new DefaultAzureCredential(credentialOptions);
+        _logger.LogInformation("AzureDevOpsApiService initialized with DefaultAzureCredential using User Assigned Managed Identity client ID: {ClientId}", azureAuthSettings.Value.ClientId);
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request updates the constructor for `AzureDevOpsApiService` to use `AzureAuthSettings` instead of `AzureOpenAISettings`, and simplifies the logic for credential initialization. The change ensures that authentication settings are sourced from the correct configuration and removes unnecessary conditional logic.

Authentication configuration update:

* The constructor now receives `IOptions<AzureAuthSettings>` and uses its `ClientId` and `TenantId` for setting up `DefaultAzureCredential`, replacing the previous use of `AzureOpenAISettings` and removing the conditional check for user-assigned identity. (`src/backend/dotnet/AzureDevOpsAI.Backend/Services/AzureDevOpsApiService.cs`, [src/backend/dotnet/AzureDevOpsAI.Backend/Services/AzureDevOpsApiService.csL47-R58](diffhunk://#diff-5eb4cf4735153d3145f98066bf0d31fce18f76621fcb5a270db65dc84a22c81aL47-R58))