### PR TITLE
removed diag settings from app insights

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -162,6 +162,8 @@ module logAnalytics 'br/public:avm/res/operational-insights/workspace:0.11.1' = 
 }
 
 // Application Insights using AVM
+// NOTE: Do not route diags from App Insights to Log Analytics to avoid
+// duplicated telemetrys
 module applicationInsights 'br/public:avm/res/insights/component:0.6.0' = {
   name: 'application-insights-${deployment().name}'
   params: {
@@ -172,22 +174,6 @@ module applicationInsights 'br/public:avm/res/insights/component:0.6.0' = {
     workspaceResourceId: logAnalytics.outputs.resourceId
     publicNetworkAccessForIngestion: 'Enabled'
     publicNetworkAccessForQuery: 'Enabled'
-    diagnosticSettings: [
-      {
-        name: 'default'
-        logCategoriesAndGroups: [
-          {
-            categoryGroup: 'allLogs'
-          }
-        ]
-        metricCategories: [
-          {
-            category: 'AllMetrics'
-          }
-        ]
-        workspaceResourceId: logAnalytics.outputs.resourceId
-      }
-    ]
   }
 }
 


### PR DESCRIPTION
This pull request updates the configuration of Application Insights in the `infra/main.bicep` file to prevent duplicate telemetry data by no longer routing diagnostics from Application Insights to Log Analytics. The main change is the removal of the `diagnosticSettings` block from the Application Insights module.

**Telemetry and diagnostics routing:**

* Added a comment clarifying that diagnostics from Application Insights should not be routed to Log Analytics to avoid duplicated telemetry.
* Removed the `diagnosticSettings` configuration from the `applicationInsights` module, so telemetry is no longer duplicated in Log Analytics.